### PR TITLE
feat: コマンド履歴の永続化とCtrl+R検索

### DIFF
--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,257 @@
+// Package history provides command history management for GoNeSh.
+package history
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	// DefaultMaxEntries is the default maximum number of history entries
+	DefaultMaxEntries = 10000
+	// HistoryFileName is the name of the history file
+	HistoryFileName = "history"
+)
+
+// History manages command history
+type History struct {
+	entries    []string
+	maxEntries int
+	filePath   string
+	mu         sync.RWMutex
+	position   int // Current position for navigation
+}
+
+// New creates a new History instance
+func New(maxEntries int) *History {
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+
+	h := &History{
+		entries:    make([]string, 0),
+		maxEntries: maxEntries,
+		position:   -1,
+	}
+
+	// Set default file path
+	h.filePath = h.defaultFilePath()
+
+	return h
+}
+
+// defaultFilePath returns the default history file path
+func (h *History) defaultFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".gonesh", HistoryFileName)
+}
+
+// Load loads history from the file
+func (h *History) Load() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.filePath == "" {
+		return nil
+	}
+
+	file, err := os.Open(h.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No history file yet
+		}
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	h.entries = make([]string, 0)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			h.entries = append(h.entries, line)
+		}
+	}
+
+	// Trim to max entries
+	if len(h.entries) > h.maxEntries {
+		h.entries = h.entries[len(h.entries)-h.maxEntries:]
+	}
+
+	h.position = len(h.entries)
+	return scanner.Err()
+}
+
+// Save saves history to the file
+func (h *History) Save() error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if h.filePath == "" {
+		return nil
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(h.filePath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	file, err := os.Create(h.filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	for _, entry := range h.entries {
+		if _, err := writer.WriteString(entry + "\n"); err != nil {
+			return err
+		}
+	}
+
+	return writer.Flush()
+}
+
+// Add adds a new entry to the history
+func (h *History) Add(entry string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return
+	}
+
+	// Don't add duplicates of the last entry
+	if len(h.entries) > 0 && h.entries[len(h.entries)-1] == entry {
+		h.position = len(h.entries)
+		return
+	}
+
+	h.entries = append(h.entries, entry)
+
+	// Trim to max entries
+	if len(h.entries) > h.maxEntries {
+		h.entries = h.entries[1:]
+	}
+
+	h.position = len(h.entries)
+}
+
+// Previous returns the previous entry in history
+func (h *History) Previous() (string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if len(h.entries) == 0 {
+		return "", false
+	}
+
+	if h.position > 0 {
+		h.position--
+	}
+
+	return h.entries[h.position], true
+}
+
+// Next returns the next entry in history
+func (h *History) Next() (string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if len(h.entries) == 0 || h.position >= len(h.entries)-1 {
+		h.position = len(h.entries)
+		return "", false
+	}
+
+	h.position++
+	return h.entries[h.position], true
+}
+
+// ResetPosition resets the history navigation position
+func (h *History) ResetPosition() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.position = len(h.entries)
+}
+
+// Search searches for entries matching the query
+func (h *History) Search(query string) []string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if query == "" {
+		return h.entries
+	}
+
+	query = strings.ToLower(query)
+	var results []string
+
+	// Search from newest to oldest
+	for i := len(h.entries) - 1; i >= 0; i-- {
+		if strings.Contains(strings.ToLower(h.entries[i]), query) {
+			results = append(results, h.entries[i])
+		}
+	}
+
+	return results
+}
+
+// SearchReverse searches for entries matching the query (reverse incremental search)
+func (h *History) SearchReverse(query string, startPos int) (string, int, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if len(h.entries) == 0 {
+		return "", -1, false
+	}
+
+	query = strings.ToLower(query)
+
+	// Start from current position and go backwards
+	start := startPos
+	if start < 0 || start >= len(h.entries) {
+		start = len(h.entries) - 1
+	}
+
+	for i := start; i >= 0; i-- {
+		if strings.Contains(strings.ToLower(h.entries[i]), query) {
+			return h.entries[i], i, true
+		}
+	}
+
+	return "", -1, false
+}
+
+// Entries returns all history entries
+func (h *History) Entries() []string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	result := make([]string, len(h.entries))
+	copy(result, h.entries)
+	return result
+}
+
+// Len returns the number of entries
+func (h *History) Len() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.entries)
+}
+
+// Clear clears all history
+func (h *History) Clear() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.entries = make([]string, 0)
+	h.position = 0
+}

--- a/internal/ui/organisms/history_search.go
+++ b/internal/ui/organisms/history_search.go
@@ -1,0 +1,220 @@
+// Package organisms provides complex UI components for GoNeSh.
+package organisms
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/ousiass/GoNeSh/internal/history"
+	"github.com/ousiass/GoNeSh/internal/ui/context"
+)
+
+// HistorySearchResult is sent when a history entry is selected
+type HistorySearchResult struct {
+	Entry    string
+	Selected bool
+}
+
+// HistorySearch represents the Ctrl+R history search UI
+type HistorySearch struct {
+	ctx      *context.UI
+	history  *history.History
+	query    string
+	results  []string
+	selected int
+	width    int
+	height   int
+	visible  bool
+	searchPos int // Current search position in history
+}
+
+// NewHistorySearch creates a new history search component
+func NewHistorySearch(ctx *context.UI, h *history.History) *HistorySearch {
+	return &HistorySearch{
+		ctx:       ctx,
+		history:   h,
+		results:   []string{},
+		selected:  0,
+		searchPos: -1,
+	}
+}
+
+// Show shows the history search UI
+func (hs *HistorySearch) Show() {
+	hs.visible = true
+	hs.query = ""
+	hs.selected = 0
+	hs.searchPos = hs.history.Len() - 1
+	hs.updateResults()
+}
+
+// Hide hides the history search UI
+func (hs *HistorySearch) Hide() {
+	hs.visible = false
+	hs.query = ""
+	hs.results = []string{}
+}
+
+// IsVisible returns whether the search UI is visible
+func (hs *HistorySearch) IsVisible() bool {
+	return hs.visible
+}
+
+// SetSize sets the component size
+func (hs *HistorySearch) SetSize(width, height int) {
+	hs.width = width
+	hs.height = height
+}
+
+// Update handles messages for the history search
+func (hs *HistorySearch) Update(msg tea.Msg) (*HistorySearch, tea.Cmd) {
+	if !hs.visible {
+		return hs, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEscape, tea.KeyCtrlC, tea.KeyCtrlG:
+			hs.Hide()
+			return hs, func() tea.Msg {
+				return HistorySearchResult{Selected: false}
+			}
+
+		case tea.KeyEnter:
+			if len(hs.results) > 0 && hs.selected < len(hs.results) {
+				entry := hs.results[hs.selected]
+				hs.Hide()
+				return hs, func() tea.Msg {
+					return HistorySearchResult{Entry: entry, Selected: true}
+				}
+			}
+			hs.Hide()
+			return hs, func() tea.Msg {
+				return HistorySearchResult{Selected: false}
+			}
+
+		case tea.KeyCtrlR:
+			// Search for next match (going backwards)
+			if len(hs.results) > 0 {
+				hs.selected = (hs.selected + 1) % len(hs.results)
+			}
+			return hs, nil
+
+		case tea.KeyUp:
+			if hs.selected > 0 {
+				hs.selected--
+			}
+			return hs, nil
+
+		case tea.KeyDown:
+			if hs.selected < len(hs.results)-1 {
+				hs.selected++
+			}
+			return hs, nil
+
+		case tea.KeyBackspace:
+			if len(hs.query) > 0 {
+				hs.query = hs.query[:len(hs.query)-1]
+				hs.updateResults()
+			}
+			return hs, nil
+
+		case tea.KeyRunes:
+			hs.query += string(msg.Runes)
+			hs.updateResults()
+			return hs, nil
+		}
+	}
+
+	return hs, nil
+}
+
+// updateResults updates the search results based on the current query
+func (hs *HistorySearch) updateResults() {
+	hs.results = hs.history.Search(hs.query)
+	hs.selected = 0
+
+	// Limit results to fit in view
+	maxResults := hs.height - 4
+	if maxResults < 1 {
+		maxResults = 5
+	}
+	if len(hs.results) > maxResults {
+		hs.results = hs.results[:maxResults]
+	}
+}
+
+// View renders the history search UI
+func (hs *HistorySearch) View() string {
+	if !hs.visible || hs.width == 0 {
+		return ""
+	}
+
+	// Build the search box
+	var sb strings.Builder
+
+	// Header
+	headerStyle := lipgloss.NewStyle().
+		Foreground(hs.ctx.Theme.Primary).
+		Bold(true)
+	sb.WriteString(headerStyle.Render("(reverse-i-search)"))
+	sb.WriteString(": ")
+
+	// Query
+	queryStyle := lipgloss.NewStyle().
+		Foreground(hs.ctx.Theme.Text)
+	sb.WriteString(queryStyle.Render(hs.query))
+	sb.WriteString("_")
+	sb.WriteString("\n")
+
+	// Results
+	for i, result := range hs.results {
+		var line string
+		if i == hs.selected {
+			// Selected item
+			selectedStyle := lipgloss.NewStyle().
+				Background(hs.ctx.Theme.Primary).
+				Foreground(hs.ctx.Theme.Bg).
+				Width(hs.width - 4)
+			line = selectedStyle.Render(truncate(result, hs.width-6))
+		} else {
+			// Normal item
+			normalStyle := lipgloss.NewStyle().
+				Foreground(hs.ctx.Theme.TextAlt).
+				Width(hs.width - 4)
+			line = normalStyle.Render(truncate(result, hs.width-6))
+		}
+		sb.WriteString("  " + line + "\n")
+	}
+
+	// Footer hint
+	hintStyle := lipgloss.NewStyle().
+		Foreground(hs.ctx.Theme.TextAlt).
+		Italic(true)
+	sb.WriteString(hintStyle.Render("Ctrl+R: next | Enter: select | Esc: cancel"))
+
+	// Box style
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(hs.ctx.Theme.Border).
+		Padding(0, 1).
+		Width(hs.width - 2)
+
+	return boxStyle.Render(sb.String())
+}
+
+// truncate truncates a string to the given length
+func truncate(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/ui/organisms/terminal.go
+++ b/internal/ui/organisms/terminal.go
@@ -302,3 +302,16 @@ func (t *Terminal) IsRunning() bool {
 	defer t.mu.Unlock()
 	return t.running
 }
+
+// SendInput sends a string to the terminal input
+func (t *Terminal) SendInput(input string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.running || t.pty == nil {
+		return
+	}
+
+	// Write the input to the PTY
+	_, _ = t.pty.Write([]byte(input))
+}


### PR DESCRIPTION
## Summary
- コマンド履歴を~/.gonesh/historyに永続化
- Ctrl+Rでインクリメンタル履歴検索

## 変更内容
- `internal/history/history.go`: 履歴管理モジュール
- `internal/ui/organisms/history_search.go`: 履歴検索UI
- `internal/core/app.go`: 履歴機能の統合
- `internal/ui/organisms/terminal.go`: SendInputメソッド追加

## Test plan
- [ ] `go build ./...` でビルド確認
- [ ] Ctrl+Rで履歴検索UIが表示される
- [ ] 文字入力でインクリメンタル検索
- [ ] Enterで選択、Escでキャンセル

Closes #2