### PR TITLE
feat: クリップボード連携機能 (#3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/ousiass/GoNeSh
 go 1.25
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
+	github.com/creack/pty v1.1.24
 	github.com/shirou/gopsutil/v4 v4.25.1
 	github.com/spf13/viper v1.20.1
 )
@@ -17,7 +19,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/creack/pty v1.1.24 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ousiass/GoNeSh
 go 1.25
 
 require (
-	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
-github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,21 +1,40 @@
-// Package clipboard provides clipboard operations for GoNeSh.
+// Package clipboard provides internal clipboard for GoNeSh.
+// This clipboard is internal to GoNeSh and works consistently
+// regardless of local or SSH environment.
 package clipboard
 
-import (
-	"github.com/atotto/clipboard"
+import "sync"
+
+var (
+	buffer string
+	mu     sync.RWMutex
 )
 
-// Copy copies text to the system clipboard
+// Copy copies text to the internal clipboard
 func Copy(text string) error {
-	return clipboard.WriteAll(text)
+	mu.Lock()
+	defer mu.Unlock()
+	buffer = text
+	return nil
 }
 
-// Paste returns text from the system clipboard
+// Paste returns text from the internal clipboard
 func Paste() (string, error) {
-	return clipboard.ReadAll()
+	mu.RLock()
+	defer mu.RUnlock()
+	return buffer, nil
 }
 
-// IsSupported returns whether clipboard operations are supported
-func IsSupported() bool {
-	return !clipboard.Unsupported
+// Clear clears the internal clipboard
+func Clear() {
+	mu.Lock()
+	defer mu.Unlock()
+	buffer = ""
+}
+
+// IsEmpty returns whether the clipboard is empty
+func IsEmpty() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return buffer == ""
 }

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,21 @@
+// Package clipboard provides clipboard operations for GoNeSh.
+package clipboard
+
+import (
+	"github.com/atotto/clipboard"
+)
+
+// Copy copies text to the system clipboard
+func Copy(text string) error {
+	return clipboard.WriteAll(text)
+}
+
+// Paste returns text from the system clipboard
+func Paste() (string, error) {
+	return clipboard.ReadAll()
+}
+
+// IsSupported returns whether clipboard operations are supported
+func IsSupported() bool {
+	return !clipboard.Unsupported
+}


### PR DESCRIPTION
## 概要
ターミナル内でのコピー＆ペースト機能を実装。

## 変更内容
- `internal/clipboard` パッケージを新規作成（GoNeSh内部クリップボード）
- ターミナルコンポーネントにクリップボード機能を統合

## 機能
- **Ctrl+Shift+V**: クリップボードから貼り付け
- **Ctrl+Shift+C**: 選択モードに入る
- 選択モード:
  - ↑↓: カーソル移動
  - PgUp/PgDown: ページ単位で移動
  - Enter/y/c: 選択範囲をコピー
  - a: 全選択
  - Esc: キャンセル
- 選択範囲のハイライト表示

## 設計判断
- **内部クリップボード**: システムクリップボード（atotto/clipboard）ではなく、GoNeSh内部のバッファを使用
- **理由**: SSH環境でも確実に動作するため
- 将来的にOSC 52でシステムクリップボード連携を追加可能

## テスト項目
- [ ] Ctrl+Shift+Vで貼り付けができる
- [ ] Ctrl+Shift+Cで選択モードに入れる
- [ ] 選択範囲がコピーされる
- [ ] SSH先でも動作する

## 関連Issue
Closes #3